### PR TITLE
Add tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,28 @@ To submit a time value in miliseconds:
 Watchman.submit("number.of.kittens", 30, :timing)
 ```
 
+## Tags
+
+If you want to use a variable that changes often, don't use this:
+
+``` ruby
+Watchman.submit("user.#{id}", 30)
+```
+
+Use tags. A list of tags is an optional last parameter of `:submit`, `:benchmark`,
+`:increment` and `:decrement` methods.
+
+For example:
+
+``` ruby
+Watchman.submit("user", 30, :gauge, ["#{id}"])
+```
+
+(Note that `:submit` has a `type` parameter with a default value of `:gauge`
+before the `tags_list` parameter)
+
+Tags list is limited to 3 values.
+
 ## Global metric prefix
 
 If you want to prepend all the metric names with a prefix, do the following:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ end
 To submit a time value in miliseconds:
 
 ``` ruby
-Watchman.submit("number.of.kittens", 30, :timing)
+Watchman.submit("number.of.kittens", 30, type: :timing)
 ```
 
 ## Tags
@@ -50,14 +50,9 @@ Watchman.submit("user.#{id}", 30)
 Use tags. A list of tags is an optional last parameter of `:submit`, `:benchmark`,
 `:increment` and `:decrement` methods.
 
-For example:
-
 ``` ruby
-Watchman.submit("user", 30, :gauge, ["#{id}"])
+Watchman.submit("user", 30, tags: ["#{id}"])
 ```
-
-(Note that `:submit` has a `type` parameter with a default value of `:gauge`
-before the `tags_list` parameter)
 
 Tags list is limited to 3 values.
 

--- a/lib/watchman.rb
+++ b/lib/watchman.rb
@@ -12,8 +12,11 @@ class Watchman
     attr_accessor :port
     attr_accessor :test_mode
 
-    def submit(name, value, type = :gauge, tags_list = [])
-      metric = metric_name_with_prefix(name, tags_list)
+    def submit(name, value, args = {})
+      type = args[:type] || :gauge
+      tags = args[:tags] || []
+
+      metric = metric_name_with_prefix(name, tags)
 
       case type
       when :gauge  then statsd_client.gauge(metric, value)
@@ -23,24 +26,30 @@ class Watchman
       end
     end
 
-    def benchmark(name, tags_list = [])
+    def benchmark(name, args = {})
+      tags = args[:tags] || []
+
       result = nil
 
       time = Benchmark.measure do
         result = yield
       end
 
-      submit(name, (time.real * 1000).floor, :timing, tags_list)
+      submit(name, (time.real * 1000).floor, type: :timing, tags: tags)
 
       result
     end
 
-    def increment(name, tags_list = [])
-      submit(name, 1, :count, tags_list)
+    def increment(name, args = {})
+      tags = args[:tags] || []
+
+      submit(name, 1, type: :count, tags: tags)
     end
 
-    def decrement(name, tags_list = [])
-      submit(name, -1, :count, tags_list)
+    def decrement(name, args = {})
+      tags = args[:tags] || []
+
+      submit(name, -1, type: :count, tags: tags)
     end
 
     private
@@ -53,18 +62,18 @@ class Watchman
       end
     end
 
-    def metric_name_with_prefix(name, tags_list)
+    def metric_name_with_prefix(name, tags)
       full_name = []
       full_name << "tagged"
       full_name << @prefix if @prefix
-      full_name << tags(tags_list)
+      full_name << tags_string(tags)
       full_name << name
       full_name.join(".")
     end
 
-    def tags(tags_list)
-      tags_list
-        .fill("no_tag", tags_list.length, [3 - tags_list.length, 0].max)
+    def tags_string(tags)
+      tags
+        .fill("no_tag", tags.length, [3 - tags.length, 0].max)
         .first(3)
         .join(".")
     end

--- a/lib/watchman/version.rb
+++ b/lib/watchman/version.rb
@@ -1,3 +1,3 @@
 class Watchman
-  VERSION = "0.7.0"
+  VERSION = "0.8.0"
 end

--- a/spec/watchman_spec.rb
+++ b/spec/watchman_spec.rb
@@ -25,7 +25,7 @@ describe Watchman do
 
     context "a ':timing' type was passed" do
       it "sends a timing value to the server" do
-        Watchman.submit("age.of.kittens", 30, :timing)
+        Watchman.submit("age.of.kittens", 30, type: :timing)
 
         sleep 1
 
@@ -35,13 +35,13 @@ describe Watchman do
 
     context "an unrecognized type was passed" do
       it "raises an exception" do
-        expect { Watchman.submit("age.of.kittens", 30, :hahha) }.to raise_exception(Watchman::SubmitTypeError)
+        expect { Watchman.submit("age.of.kittens", 30, type: :hahha) }.to raise_exception(Watchman::SubmitTypeError)
       end
     end
 
     context "a tag was passed" do
       it "sends the value to statsd server" do
-        Watchman.submit("number.of.kittens", 30, :gauge, ["mytag"])
+        Watchman.submit("number.of.kittens", 30, tags: ["mytag"])
 
         sleep 1
 
@@ -52,7 +52,7 @@ describe Watchman do
 
   describe ".increment" do
     it "increments the value of a metric" do
-      Watchman.increment("number.of.kittens", ["mytag"])
+      Watchman.increment("number.of.kittens", tags: ["mytag"])
 
       sleep 1
 
@@ -62,7 +62,7 @@ describe Watchman do
 
   describe ".decrement" do
     it "decrements the value of a metric" do
-      Watchman.decrement("number.of.kittens", ["mytag"])
+      Watchman.decrement("number.of.kittens", tags: ["mytag"])
 
       sleep 1
 
@@ -72,7 +72,7 @@ describe Watchman do
 
   describe ".benchmark" do
     it "measures the execution of the method in miliseconds" do
-      Watchman.benchmark("sleep.time", ["mytag"]) do
+      Watchman.benchmark("sleep.time", tags: ["mytag"]) do
         sleep 1
       end
 


### PR DESCRIPTION
Adds tagging as seen [here](https://github.com/renderedtext/ex-watchman/blob/master/README.md#tags) and [here](https://github.com/renderedtext/ex-watchman/blob/master/lib/watchman/server.ex#L57).

Adding it to `submit` wasn't ideal because of the default parameter, but doing otherwise would've broken the interface for those already using Watchman.