### PR TITLE
Enable tagging for cloudwatch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in watchman.gemspec
 gemspec
+gem 'dogstatsd-ruby', "~> 5.5.0"

--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ Watchman.submit("user", 30, tags: [id])
 
 Tags list is limited to 3 values.
 
+## Tags for datadog/cloudwatch
+In case you want your metrics to be formated with cloudwatch style taggs, you need to provide tags
+in this style
+``` ruby
+Watchman.submit("age.of.kittens", 30, :timing, :tags => ["tag:a"])
+```
 ## Global metric prefix
 
 If you want to prepend all the metric names with a prefix, do the following:

--- a/lib/watchman/mock_statsd.rb
+++ b/lib/watchman/mock_statsd.rb
@@ -3,9 +3,9 @@ class Watchman
 
     # Used in test environments
 
-    def gauge(metric, value); end
-    def timing(metric, value); end
-    def count(metric, value); end
+    def gauge(metric, value, tags = {}); end
+    def timing(metric, value, tags = {}); end
+    def count(metric, value, tags = {}); end
 
   end
 end

--- a/lib/watchman/tagged_metric_name.rb
+++ b/lib/watchman/tagged_metric_name.rb
@@ -1,5 +1,5 @@
 class Watchman
-  class MetricName
+  class TaggedMetricName
     def self.construct(base_name, prefix, tags)
       new(base_name, prefix, tags).construct
     end

--- a/lib/watchman/untagged_metric_name.rb
+++ b/lib/watchman/untagged_metric_name.rb
@@ -1,0 +1,22 @@
+class Watchman
+    class UntaggedMetricName
+      def self.construct(base_name, prefix)
+        new(base_name, prefix).construct
+      end
+  
+      def initialize(base_name, prefix = nil)
+        @base_name = base_name
+        @prefix = prefix
+      end
+  
+      def construct
+        full_name = []
+  
+        full_name << @prefix       if @prefix
+        full_name << @base_name
+  
+        full_name.join(".")
+      end
+    end
+  end
+  

--- a/spec/watchman_spec.rb
+++ b/spec/watchman_spec.rb
@@ -97,6 +97,24 @@ describe Watchman do
     
   end
 
+  describe ".cloudwatch_backend" do
+    before(:all) do
+      Watchman.external_backend = :aws_cloudwatch
+    end
+    
+    after(:all) do
+      Watchman.external_backend = nil 
+    end
+
+    it "formats tags at the end of the metric for cloudwatch, less than 3 tags" do
+      Watchman.submit("age.of.kittens", 30, :timing, :tags => ["tag:a"])
+
+      sleep 1
+
+      expect(@test_server.recvfrom(200).first).to eq("prod.age.of.kittens:30|ms|#tag:a")
+    end
+  end
+
   describe ".timing" do
     it "sends timing value" do
       Watchman.timing("speed.of.kittens", 30)


### PR DESCRIPTION
Moving to datadog [statsd client](https://github.com/DataDog/dogstatsd-ruby), and introducing external_backend configuration option.